### PR TITLE
Get addresses using keys instead of scan

### DIFF
--- a/payment/models.py
+++ b/payment/models.py
@@ -131,18 +131,18 @@ class Watcher():
     @classmethod
     def get_all_addresses(cls):
         # Get all keys that are addresses
-        data = redis_conn.scan(0,"*:G*")
+        data = redis_conn.keys("*:G*")
         # Create a list of addresses by decoding the  byte strings and taking everything after ":"
-        addresses = [key.decode().split(':')[1] for key in data[1]]
+        addresses = [key.decode().split(':')[1] for key in data]
         return addresses
 
     @classmethod
     def get_subscribed(cls, address):
         """get services interested in an address."""
         # Get all keys that are addresses
-        data = redis_conn.scan(0, "*:{}".format(address))
+        data = redis_conn.keys("*:{}".format(address))
         # Create a list of addresses by decoding the  byte strings and taking everything before ":"
-        services = [key.decode().split(':')[0] for key in data[1]]
+        services = [key.decode().split(':')[0] for key in data]
         return services
 
 


### PR DESCRIPTION
PR template:
* PR Title:
P2P - Fix p2p watchers
* Main purpose:
Sometimes the payment-service didn't get all addresses to watch from the database
* Technical description:
Get addresses from Redis using ['keys'](https://www.google.co.il/search?q=redis+keys&oq=redis+keys&aqs=chrome.0.0l6.4398j0j1&sourceid=chrome&ie=UTF-8) instead of ['scan'](https://redis.io/commands/scan), scan is cursor based and thus might not fetch all keys, you need to iterate yourself on the next cursor until cursor 0 is returned, `keys` the entire db