### PR TITLE
Create wallets using the right address

### DIFF
--- a/payment/blockchain.py
+++ b/payment/blockchain.py
@@ -114,7 +114,7 @@ for ds, seeds in APP_SEEDS.items():
 
     joined_sdk = Blockchain.read_sdk.kin_account(seeds.joined, app_id=ds)
     _write_sdks[Keypair.address_from_seed(seeds.joined)] = joined_sdk
-    _write_sdks[root_account.get_public_address()] = root_account
+_write_sdks[root_account.get_public_address()] = root_account
 
 
 @contextlib.contextmanager

--- a/payment/blockchain.py
+++ b/payment/blockchain.py
@@ -114,6 +114,7 @@ for ds, seeds in APP_SEEDS.items():
 
     joined_sdk = Blockchain.read_sdk.kin_account(seeds.joined, app_id=ds)
     _write_sdks[Keypair.address_from_seed(seeds.joined)] = joined_sdk
+    _write_sdks[root_account.get_public_address()] = root_account
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Changes:
1. Add the root wallet to the sdks dictionary
2. Create accounts using the app's wallet, instead of with the root account.

(These was how it worked on my pc when we tested, but due to config issue this was not applied)