### PR TITLE
Fix whitelist

### DIFF
--- a/payment/channel_factory.py
+++ b/payment/channel_factory.py
@@ -3,7 +3,6 @@ import time
 from random import randint
 from hashlib import sha256
 from kin_base import Keypair
-from kin import KinErrors
 from .utils import lock
 from . import config
 from .redis_conn import redis_conn
@@ -45,8 +44,4 @@ def get_channel(root_wallet: Blockchain):
     """gets next channel_id from redis, generates address/ tops up and inits sdk."""
     with get_next_channel_id() as channel_id:
         keys = generate_key(root_wallet, channel_id)
-        public_address = keys.address().decode()
-        if not root_wallet.read_sdk.does_account_exists(public_address):
-            root_wallet.create_wallet(public_address)
-            log.info('# created channel: %s: %s' % (channel_id, public_address))
         yield keys.seed().decode()

--- a/payment/models.py
+++ b/payment/models.py
@@ -6,6 +6,7 @@ from schematics.types import StringType, IntType, DateTimeType, BooleanType
 from kin.transactions import NATIVE_ASSET_TYPE, SimplifiedTransaction
 from kin import decode_transaction
 from kin import KinErrors
+from kin import Keypair
 from .errors import PaymentNotFoundError, ParseError, OrderNotFoundError, TransactionMismatch
 from .redis_conn import redis_conn
 from .log import get as get_log
@@ -99,14 +100,14 @@ class WhitelistRequest(ModelWithStr):
 
     def whitelist(self) -> str:
         """Sign and return a transaction to whitelist it"""
-        # Get app hot wallet account
         # Fix for circular imports
         # https://stackoverflow.com/questions/1250103/attributeerror-module-object-has-no-attribute
-        from .blockchain import get_sdk
+        from .blockchain import _write_sdks
         app_seed = APP_SEEDS.get(self.app_id).our
-        with get_sdk(app_seed) as hot_account:
-            return hot_account.write_sdk.whitelist_transaction({'envelope': self.xdr,
-                                                                'network_id': self.network_id})
+        # Get app hot wallet account
+        hot_account = _write_sdks[Keypair.address_from_seed(app_seed)]
+        return hot_account.whitelist_transaction({'envelope': self.xdr,
+                                                  'network_id': self.network_id})
 
 
 class Payment(ModelWithStr):


### PR DESCRIPTION
 Two bug fixes:
1. Don't lock channels when whitelisting a transaction
2. We now per-create all channels, so there is no need to see if the are created